### PR TITLE
POM plugin management to use the latest maven-deploy-plugin, 2.8.2.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,12 +21,25 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <maven-deploy-plugin-version>2.8.2</maven-deploy-plugin-version>
     </properties>
 
     <modules>
         <module>owltools2-core</module>
         <module>owltools2-command</module>
     </modules>
+
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-deploy-plugin</artifactId>
+          <version>${maven-deploy-plugin-version}</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
 
     <dependencies>
         <dependency>


### PR DESCRIPTION
Version 2.8+ has a new feature that allows the deployment of artifacts
to be delayed until the full Maven build is finished. This helps avoid
partial deployments if one of the later build projects fails. Otherwise,
the depolyed artifacts will not be consistent.